### PR TITLE
Readme: fix typo prettier vs eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ As a result, Prettier will add `{}` curly brackets to control flow statements su
 
 Prettier generally does not modify the structure of code: which includes [not enforcing curly brackets](https://github.com/prettier/prettier/issues/7659) to match [ESLint's `curly` rule](https://eslint.org/docs/latest/rules/curly).
 However, enforcing `curly` generally does not modify code runtime behavior, and is often desirable for code consistency and to avoid accidental bugs.
-This plugin enforces the equivalent of [`curly`'s `all` option](https://eslint.org/docs/latest/rules/curly#all) at the Prettier level.
+This plugin enforces the equivalent of [`eslint`'s `all` option](https://eslint.org/docs/latest/rules/curly#all) at the Prettier level.
 
 > See [The Blurry Line Between Formatting and Style](https://blog.joshuakgoldberg.com/the-blurry-line-between-formatting-and-style) for more details.
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/prettier-plugin-curly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/prettier-plugin-curly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
I am pretty sure that this is a typo.
Keep up the good work in the TS and JS world.