### PR TITLE
fix: handle non-block else statements

### DIFF
--- a/src/preprocess.test.ts
+++ b/src/preprocess.test.ts
@@ -17,6 +17,7 @@ describe("preprocess", () => {
 		[`if (a) b;`, `if (a) { b; }`],
 		[`if (a) { b; }`, `if (a) { b; }`],
 		[`if (a) b; else c;`, `if (a) { b; } else { c; }`],
+		[`if (a) {} else b;`, `if (a) {} else { b; }`],
 		[`if (a) b; else { c; }`, `if (a) { b; } else { c; }`],
 		[`if (a) b; else if (b) c;`, `if (a) { b; } else if (b) { c; }`],
 		["let a; let a;", "let a; let a;"],

--- a/src/printNodeWithBrackets.ts
+++ b/src/printNodeWithBrackets.ts
@@ -4,57 +4,69 @@ export function printNodeWithBrackets(code: string, node: CollectibleNode) {
 	/* eslint-disable @typescript-eslint/no-non-null-assertion */
 	switch (node.type) {
 		case "DoWhileStatement":
-			return [
-				"do { ",
-				code.slice(node.body.start!, node.body.end!),
-				" } while (",
-				code.slice(node.test.start!, node.test.end!),
-				")",
-			].join("");
+			return node.body.type === "BlockStatement"
+				? code.slice(...node.range!)
+				: [
+						"do { ",
+						code.slice(node.body.start!, node.body.end!),
+						" } while (",
+						code.slice(node.test.start!, node.test.end!),
+						")",
+				  ].join("");
 
 		case "ForStatement":
-			return [
-				"for (",
-				node.init && code.slice(node.init.start!, node.init.end!),
-				"; ",
-				node.test && code.slice(node.test.start!, node.test.end!),
-				"; ",
-				node.update && code.slice(node.update.start!, node.update.end!),
-				") { ",
-				code.slice(node.body.start!, node.body.end!),
-				" }",
-			]
-				.filter(Boolean)
-				.join("");
+			return node.body.type === "BlockStatement"
+				? code.slice(...node.range!)
+				: [
+						"for (",
+						node.init && code.slice(node.init.start!, node.init.end!),
+						"; ",
+						node.test && code.slice(node.test.start!, node.test.end!),
+						"; ",
+						node.update && code.slice(node.update.start!, node.update.end!),
+						") { ",
+						code.slice(node.body.start!, node.body.end!),
+						" }",
+				  ]
+						.filter(Boolean)
+						.join("");
 
 		case "ForInStatement":
-			return [
-				"for (",
-				code.slice(node.left.start!, node.left.end!),
-				" in ",
-				code.slice(node.right.start!, node.right.end!),
-				") { ",
-				code.slice(node.body.start!, node.body.end!),
-				" }",
-			].join("");
+			return node.body.type === "BlockStatement"
+				? code.slice(...node.range!)
+				: [
+						"for (",
+						code.slice(node.left.start!, node.left.end!),
+						" in ",
+						code.slice(node.right.start!, node.right.end!),
+						") { ",
+						code.slice(node.body.start!, node.body.end!),
+						" }",
+				  ].join("");
 
 		case "ForOfStatement":
-			return [
-				"for (",
-				code.slice(node.left.start!, node.left.end!),
-				" of ",
-				code.slice(node.right.start!, node.right.end!),
-				") { ",
-				code.slice(node.body.start!, node.body.end!),
-				" }",
-			].join("");
+			return node.body.type === "BlockStatement"
+				? code.slice(...node.range!)
+				: [
+						"for (",
+						code.slice(node.left.start!, node.left.end!),
+						" of ",
+						code.slice(node.right.start!, node.right.end!),
+						") { ",
+						code.slice(node.body.start!, node.body.end!),
+						" }",
+				  ].join("");
 
 		case "IfStatement":
 			return [
-				code.slice(node.start!, node.test.end!),
-				") { ",
-				code.slice(node.consequent.start!, node.consequent.end!),
-				" }",
+				node.consequent.type === "BlockStatement"
+					? [code.slice(node.range![0], node.consequent.range![1])]
+					: [
+							code.slice(node.start!, node.test.end!),
+							") { ",
+							code.slice(node.consequent.start!, node.consequent.end!),
+							" }",
+					  ],
 				node.alternate && [
 					" else ",
 					node.alternate.type !== "IfStatement" && [
@@ -69,12 +81,14 @@ export function printNodeWithBrackets(code: string, node: CollectibleNode) {
 				.join("");
 
 		case "WhileStatement":
-			return [
-				code.slice(node.start!, node.test.end!),
-				") { ",
-				code.slice(node.body.start!, node.end!),
-				" }",
-			].join("");
+			return node.body.type === "BlockStatement"
+				? code.slice(...node.range!)
+				: [
+						code.slice(node.start!, node.test.end!),
+						") { ",
+						code.slice(node.body.start!, node.end!),
+						" }",
+				  ].join("");
 	}
 	/* eslint-enable @typescript-eslint/no-non-null-assertion */
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #252
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/prettier-plugin-curly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/prettier-plugin-curly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

If an _IfStatement_ has a block body but its `consequent` (_ElseStatement_) doesn't, then the `consequent` still needs to be fixed. Which means the code's old "collector" logic is not valid.