### PR TITLE
fix: support running inside a CommonJS module

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,18 @@
 		"name": "JoshuaKGoldberg",
 		"email": "npm@joshuakgoldberg.com"
 	},
-	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/index.d.mts",
+				"default": "./lib/index.mjs"
+			},
+			"require": {
+				"types": "./lib/index.d.ts",
+				"default": "./lib/index.js"
+			}
+		}
+	},
 	"main": "./lib/index.js",
 	"files": [
 		"lib/",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,18 @@
 import { Parser } from "prettier";
-import babel from "prettier/parser-babel";
-import typescript from "prettier/parser-typescript";
+import * as babel from "prettier/parser-babel";
+import * as typescript from "prettier/parser-typescript";
 
 import { preprocess } from "./preprocess.js";
 
 export const parsers = {
 	babel: {
-		...babel.parsers.babel,
+		// @ts-ignore
+		...(babel.default || babel).parsers.babel,
 		preprocess,
 	},
 	typescript: {
-		...typescript.parsers.typescript,
+		// @ts-ignore
+		...(typescript.default || typescript).parsers.typescript,
 		preprocess,
 	},
 } satisfies Record<string, Parser>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+// CJS/ESM 🫠
+/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
 import { Parser } from "prettier";
 import * as babel from "prettier/parser-babel";
 import * as typescript from "prettier/parser-typescript";
@@ -16,3 +18,5 @@ export const parsers = {
 		preprocess,
 	},
 } satisfies Record<string, Parser>;
+
+/* eslint-enable */

--- a/src/reprintAst.ts
+++ b/src/reprintAst.ts
@@ -1,3 +1,5 @@
+// CJS/ESM 🫠
+/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-plus-operands */
 import generate, { GeneratorOptions } from "@babel/generator";
 
 import { CollectibleNode } from "./types.js";
@@ -22,7 +24,7 @@ export function reprintAst(code: string, collectedNodes: CollectibleNode[]) {
 		output += code.slice(lastEnd, collectedNode.start!);
 
 		// See https://github.com/prettier/prettier/issues/9114 for a Prettier AST format API.
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+
 		// @ts-ignore
 		output += (generate.default || generate)(collectedNode, printOptions).code;
 
@@ -32,3 +34,5 @@ export function reprintAst(code: string, collectedNodes: CollectibleNode[]) {
 
 	return output + code.slice(lastEnd);
 }
+
+/* eslint-enable */

--- a/src/reprintAst.ts
+++ b/src/reprintAst.ts
@@ -23,6 +23,7 @@ export function reprintAst(code: string, collectedNodes: CollectibleNode[]) {
 
 		// See https://github.com/prettier/prettier/issues/9114 for a Prettier AST format API.
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		// @ts-ignore
 		output += (generate.default || generate)(collectedNode, printOptions).code;
 
 		lastEnd = collectedNode.end!;

--- a/src/traverseAndModifyAst.ts
+++ b/src/traverseAndModifyAst.ts
@@ -17,6 +17,7 @@ export function traverseAndModifyAst(ast: Node) {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- CJS/ESM 🫠
+	// @ts-ignore
 	(traverse.default || traverse)(ast, {
 		DoWhileStatement: collector,
 		ForInStatement: collector,
@@ -38,7 +39,9 @@ function nodeNotAlreadySeen(node: Node, seenNodes: Set<Node>) {
 	// All child nodes are marked as seen and removed from collections,
 	// so that we don't accidentally print overlapping fixes for them later.
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- CJS/ESM 🫠
+	// @ts-ignore
 	(traverse.default || traverse)(node, {
+		// @ts-ignore
 		enter(path) {
 			seenNodes.add(path.node);
 		},

--- a/src/traverseAndModifyAst.ts
+++ b/src/traverseAndModifyAst.ts
@@ -1,3 +1,6 @@
+// CJS/ESM 🫠
+/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+
 import traverse, { Node, NodePath } from "@babel/traverse";
 
 import { modifyNodeIfMissingBrackets } from "./modifyNodeIfMissingBrackets.js";
@@ -16,7 +19,6 @@ export function traverseAndModifyAst(ast: Node) {
 		}
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- CJS/ESM 🫠
 	// @ts-ignore
 	(traverse.default || traverse)(ast, {
 		DoWhileStatement: collector,
@@ -38,7 +40,6 @@ function nodeNotAlreadySeen(node: Node, seenNodes: Set<Node>) {
 
 	// All child nodes are marked as seen and removed from collections,
 	// so that we don't accidentally print overlapping fixes for them later.
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- CJS/ESM 🫠
 	// @ts-ignore
 	(traverse.default || traverse)(node, {
 		// @ts-ignore
@@ -52,3 +53,5 @@ function nodeNotAlreadySeen(node: Node, seenNodes: Set<Node>) {
 
 	return true;
 }
+
+/* eslint-enable */

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
 	clean: true,
 	dts: true,
 	entry: ["src/**/*.ts", "!src/**/*.test.*"],
-	format: "esm",
+	format: ["cjs", "esm"],
 	outDir: "lib",
 	sourcemap: true,
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #545
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/prettier-plugin-curly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/prettier-plugin-curly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The main fix here is removing `"type": "module"` from `package.json` 😞. Prettier loads in CJS mode no matter what, so trying to import `.js` files with ESM imports causes the `require()` complaints. 

I couldn't figure out a clean way to get ESBuild/tsup to switch `.js` extensions in source files to switch to `.cjs`/`.mjs` in outputs. Which is probably for the best, that'd be spooky...

Two followups:

* Hardens against default/namespace import confusion in a couple of places that started complaining
* Corrected `package.json`'s `"exports"` to reflect that there are now two emit modes

💖 